### PR TITLE
FT-publications-module

### DIFF
--- a/prisma/migrations/20251028223307_publication_migration/migration.sql
+++ b/prisma/migrations/20251028223307_publication_migration/migration.sql
@@ -1,0 +1,22 @@
+-- CreateEnum
+CREATE TYPE "PublicationTypes" AS ENUM ('ARTICLE', 'MAGAZINE', 'NEWSPAPER');
+
+-- CreateTable
+CREATE TABLE "Publication" (
+    "id" SERIAL NOT NULL,
+    "type" "PublicationTypes" NOT NULL,
+    "title" TEXT NOT NULL,
+    "author" TEXT NOT NULL,
+    "author_two" TEXT,
+    "author_three" TEXT,
+    "copies" INTEGER NOT NULL,
+    "ISBN" TEXT,
+    "ISSN" TEXT,
+    "available" BOOLEAN NOT NULL DEFAULT true,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Publication_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Publication_title_key" ON "Publication"("title");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -15,6 +15,12 @@ enum Roles {
   PROFESSOR
 }
 
+enum PublicationTypes {
+  ARTICLE
+  MAGAZINE
+  NEWSPAPER
+}
+
 model User {
   id           String    @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
   name         String    @db.VarChar(120)
@@ -50,4 +56,18 @@ model Thesis {
   thesis_advisor String
   copies         Int
   created_at     DateTime @default(now())
+}
+
+model Publication {
+  id           Int              @id @default(autoincrement())
+  type         PublicationTypes
+  title        String           @unique
+  author       String
+  author_two   String?
+  author_three String?
+  copies       Int
+  ISBN         String?
+  ISSN         String?
+  available    Boolean          @default(true)
+  created_at   DateTime         @default(now())
 }

--- a/src/controllers/publication.controller.ts
+++ b/src/controllers/publication.controller.ts
@@ -1,0 +1,104 @@
+import { ApiResponseHandler } from '@api/apiResponseHandler';
+import { PublicationService } from '@services/publication.service';
+
+import { Request, Response } from 'express';
+
+export class PublicationController {
+  private apiResponseHandler = new ApiResponseHandler();
+
+  constructor(private publicationService: PublicationService) {}
+
+  public async getAllPublications(_: Request, res: Response) {
+    try {
+      const result = await this.publicationService.getAllPublications();
+
+      if (result.success) {
+        this.apiResponseHandler.successResponse(
+          res,
+          'Publicaciones obtenidas existosamente',
+          result.data
+        );
+      } else {
+        this.apiResponseHandler.notFoundResponse(res, result.error);
+      }
+    } catch (error) {
+      this.apiResponseHandler.internalServerErrorResponse(
+        res,
+        'Error interno del servidor'
+      );
+    }
+  }
+
+  public async updatePublication(req: Request, res: Response) {
+    try {
+      const publication = req.body;
+
+      const result = await this.publicationService.updatePublicationFields(
+        publication
+      );
+
+      if (result.success) {
+        this.apiResponseHandler.successResponse(
+          res,
+          'Publicación actualizada',
+          result.data
+        );
+      } else {
+        this.apiResponseHandler.notFoundResponse(res, result.error);
+      }
+    } catch (error) {
+      this.apiResponseHandler.internalServerErrorResponse(
+        res,
+        'Error interno del servidor'
+      );
+    }
+  }
+
+  public async createNewPublication(req: Request, res: Response) {
+    try {
+      const publication = req.body;
+
+      const result = await this.publicationService.createPublication(
+        publication
+      );
+
+      if (result.success) {
+        this.apiResponseHandler.successCreationResponse(
+          res,
+          'Recurso creado correctamente',
+          result.data
+        );
+      } else {
+        this.apiResponseHandler.badRequestResponse(res, result.error);
+      }
+    } catch (error) {
+      this.apiResponseHandler.internalServerErrorResponse(
+        res,
+        `Error: ${error}`
+      );
+    }
+  }
+
+  public async deletePublication(req: Request, res: Response) {
+    try {
+      const { id } = req.body;
+
+      const result = await this.publicationService.deletePublicationbyId(id);
+
+      if (result.success) {
+        this.apiResponseHandler.successResponse(
+          res,
+          'Elemento eliminado correctamente',
+          result.data
+        );
+      } else {
+        this.apiResponseHandler.badRequestResponse(res, result.error);
+      }
+    } catch (error) {
+      this.apiResponseHandler.internalServerErrorResponse(
+        res,
+        `Error: ${error}`
+      );
+    }
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import authRouter from '@routes/authentication.route';
 import bookRouter from '@routes/book.route';
 import userRouter from '@routes/user.route';
 import thesisRouter from '@routes/thesis.route';
+import publicationRouter from '@routes/publication.route';
 
 const app = express();
 const PORT = process.env.PORT;
@@ -19,5 +20,6 @@ app.use('/api/auth', authRouter);
 app.use('/api/users', userRouter);
 app.use('/api/books', bookRouter);
 app.use('/api/thesis', thesisRouter);
+app.use('/api/publications', publicationRouter);
 
 app.listen(PORT, () => console.log(`Server listening on port: ${PORT}`));

--- a/src/interfaces/publication.interface.ts
+++ b/src/interfaces/publication.interface.ts
@@ -4,26 +4,26 @@ import { Result } from './api.interface';
 
 export interface IPublication extends Publication {}
 
-export type IPublicationCreationDTO = Omit<IPublication, 'id' | 'created_at'>;
+export type PublicationCreationDTO = Omit<IPublication, 'id' | 'created_at'>;
 
 export interface IPublicationRepository {
-  Create(publication: IPublicationCreationDTO): Promise<IPublication>;
+  Create(publication: PublicationCreationDTO): Promise<IPublication>;
   FindById(publicationId: number): Promise<IPublication | null>;
   FindAll(): Promise<IPublication[]>;
   Update(
     publicationId: number,
-    publication: IPublicationCreationDTO
+    publication: PublicationCreationDTO
   ): Promise<IPublication>;
   Delete(publicationId: number): Promise<IPublication>;
 }
 
 export interface IPublicationService {
-  getAllPublications(): Result<IPublication[]>;
+  getAllPublications(): Promise<Result<IPublication[]>>;
   createPublication(
-    publication: IPublicationCreationDTO
+    publication: PublicationCreationDTO
   ): Promise<Result<IPublication>>;
   updatePublicationFields(
-    publication: IPublicationCreationDTO
+    publication: Omit<PublicationCreationDTO, 'created_at'>
   ): Promise<Result<IPublication>>;
   deletePublicationbyId(publicationId: number): Promise<Result<IPublication>>;
 }

--- a/src/interfaces/publication.interface.ts
+++ b/src/interfaces/publication.interface.ts
@@ -1,17 +1,29 @@
-export interface Publication {
-  id?: number;
-  type: PublicationTypes;
-  title: string;
-  author: string;
-  author_two?: string;
-  author_three?: string;
-  copies: number;
-  ISBN: number;
-  ISSN?: number;
+import { Publication, PublicationTypes } from 'prisma/prisma-client';
+
+import { Result } from './api.interface';
+
+export interface IPublication extends Publication {}
+
+export type IPublicationCreationDTO = Omit<IPublication, 'id' | 'created_at'>;
+
+export interface IPublicationRepository {
+  Create(publication: IPublicationCreationDTO): Promise<IPublication>;
+  FindById(publicationId: number): Promise<IPublication | null>;
+  FindAll(): Promise<IPublication[]>;
+  Update(
+    publicationId: number,
+    publication: IPublicationCreationDTO
+  ): Promise<IPublication>;
+  Delete(publicationId: number): Promise<IPublication>;
 }
 
-export enum PublicationTypes {
-  article = 1,
-  magazine = 2,
-  newpaper = 3,
+export interface IPublicationService {
+  getAllPublications(): Result<IPublication[]>;
+  createPublication(
+    publication: IPublicationCreationDTO
+  ): Promise<Result<IPublication>>;
+  updatePublicationFields(
+    publication: IPublicationCreationDTO
+  ): Promise<Result<IPublication>>;
+  deletePublicationbyId(publicationId: number): Promise<Result<IPublication>>;
 }

--- a/src/repositories/publication.respository.ts
+++ b/src/repositories/publication.respository.ts
@@ -1,0 +1,90 @@
+import {
+  IPublication,
+  IPublicationCreationDTO,
+} from '@interfaces/publication.interface';
+import { errorHandler } from '@utils/handlePrismaKnownRequestError';
+import { PrismaClient } from 'prisma/prisma-client';
+
+export class PublicationRepository implements PublicationRepository {
+  private prisma = new PrismaClient();
+
+  public async Create(
+    publication: IPublicationCreationDTO
+  ): Promise<IPublication> {
+    if (publication === null) throw new Error('Publication ivalid');
+    try {
+      const publicationExists = await this.prisma.publication.findUnique({
+        where: { title: publication.title },
+      });
+
+      if (publicationExists) throw new Error('Publication already exists');
+      const newPublication = await this.prisma.publication.create({
+        data: publication,
+      });
+
+      return newPublication;
+    } catch (error) {
+      return errorHandler(error, 'book.repository');
+    }
+  }
+
+  public async FindById(publicationId: number): Promise<IPublication | null> {
+    if (publicationId === null) throw new Error('Publication ivalid');
+    try {
+      const publication = await this.prisma.publication.findUnique({
+        where: { id: publicationId },
+      });
+
+      return publication;
+    } catch (error) {
+      return errorHandler(error, 'book.repository');
+    }
+  }
+
+  public async FindAll(): Promise<IPublication[]> {
+    try {
+      const publicationsList = await this.prisma.publication.findMany();
+
+      return publicationsList;
+    } catch (error) {
+      return errorHandler(error, 'book.repository');
+    }
+  }
+  public async Update(
+    publicationId: number,
+    publication: IPublicationCreationDTO
+  ): Promise<IPublication> {
+    if (publication === null) throw new Error('Publication ivalid');
+
+    try {
+      const updatedPublication = await this.prisma.publication.update({
+        where: { id: publicationId },
+        data: publication,
+      });
+
+      return updatedPublication;
+    } catch (error) {
+      return errorHandler(error, 'book.repository');
+    }
+  }
+
+  public async Delete(publicationId: number): Promise<IPublication> {
+    if (!publicationId) throw new Error('El ID de la publicacion es necesario');
+
+    try {
+      const publicationExists = await this.prisma.publication.findUnique({
+        where: { id: publicationId },
+      });
+
+      if (!publicationExists) throw new Error('Publication does not exists');
+
+      const deletedPublication = await this.prisma.publication.delete({
+        where: { id: publicationId },
+      });
+
+      return deletedPublication;
+    } catch (error) {
+      return errorHandler(error, 'book.repository');
+    }
+  }
+}

--- a/src/repositories/publication.respository.ts
+++ b/src/repositories/publication.respository.ts
@@ -1,6 +1,6 @@
 import {
   IPublication,
-  IPublicationCreationDTO,
+  PublicationCreationDTO,
 } from '@interfaces/publication.interface';
 import { errorHandler } from '@utils/handlePrismaKnownRequestError';
 import { PrismaClient } from 'prisma/prisma-client';
@@ -9,7 +9,7 @@ export class PublicationRepository implements PublicationRepository {
   private prisma = new PrismaClient();
 
   public async Create(
-    publication: IPublicationCreationDTO
+    publication: PublicationCreationDTO
   ): Promise<IPublication> {
     if (publication === null) throw new Error('Publication ivalid');
     try {
@@ -52,7 +52,7 @@ export class PublicationRepository implements PublicationRepository {
   }
   public async Update(
     publicationId: number,
-    publication: IPublicationCreationDTO
+    publication: Partial<PublicationCreationDTO>
   ): Promise<IPublication> {
     if (publication === null) throw new Error('Publication ivalid');
 

--- a/src/routes/publication.route.ts
+++ b/src/routes/publication.route.ts
@@ -1,0 +1,30 @@
+import { Request, Response, Router } from 'express';
+
+import { PublicationController } from '@controllers/publication.controller';
+import { PublicationService } from '@services/publication.service';
+import { publicationFieldsValidation } from '@schemas/publication/publicationValidationFields.schema';
+
+const router = Router();
+const publicationService = new PublicationService();
+const publicationController = new PublicationController(publicationService);
+
+router.post(
+  '/create-publication',
+  publicationFieldsValidation,
+  (req: Request, res: Response) =>
+    publicationController.createNewPublication(req, res)
+);
+
+router.get('/all-publications', (req: Request, res: Response) =>
+  publicationController.getAllPublications(req, res)
+);
+
+router.put('/update-publication', (req: Request, res: Response) =>
+  publicationController.updatePublication(req, res)
+);
+
+router.delete('/delete-publication', (req: Request, res: Response) =>
+  publicationController.deletePublication(req, res)
+);
+
+export default router;

--- a/src/schemas/publication/publicationValidationFields.schema.ts
+++ b/src/schemas/publication/publicationValidationFields.schema.ts
@@ -1,0 +1,45 @@
+import { NextFunction, Request, Response } from 'express';
+import { check } from 'express-validator';
+import { PublicationTypes } from 'prisma/prisma-client';
+
+import { fieldsValidator } from 'middlewares/fieldsValidator';
+
+export const publicationFieldsValidation = [
+  check('title')
+    .notEmpty()
+    .withMessage('El título es obligatorio')
+    .isLength({ max: 120 })
+    .withMessage('El título no puede tener más de 120 caracteres'),
+
+  check('type')
+    .notEmpty()
+    .withMessage('El título es obligatorio')
+    .isIn(Object.values(PublicationTypes))
+    .withMessage(
+      `El tipo de publicación debe ser del tipo: ${Object.values(
+        PublicationTypes
+      ).join(', ')}`
+    ),
+
+  check('author')
+    .notEmpty()
+    .withMessage('El nombre del autor es obligatorio')
+    .isLength({ max: 120 })
+    .withMessage('El nombre del autor no puede tener más de 120 caracteres'),
+
+  check('ISBN').isISBN().withMessage('El ISBN debe ser válido').optional(),
+
+  check('ISSN').isISSN().withMessage('El ISSN debe ser válido').optional(),
+
+  check('copies')
+    .notEmpty()
+    .withMessage('El número de copias es obligatorio')
+    .isNumeric()
+    .withMessage('El número de copias debe ser un valor numérico')
+    .isLength({ max: 1 })
+    .withMessage('No se pueden registrar mas de 9 copias de un mismo ejemplar'),
+
+  (req: Request, res: Response, next: NextFunction) => {
+    fieldsValidator(req, res, next);
+  },
+];

--- a/src/services/publication.service.ts
+++ b/src/services/publication.service.ts
@@ -1,0 +1,100 @@
+import { Result } from '@interfaces/api.interface';
+import {
+  IPublication,
+  IPublicationService,
+  PublicationCreationDTO,
+} from '@interfaces/publication.interface';
+import { PublicationRepository } from '@repositories/publication.respository';
+
+import { generateResult } from '@utils/generateResult';
+
+export class PublicationService implements IPublicationService {
+  private publicationRepository: PublicationRepository;
+
+  constructor() {
+    this.publicationRepository = new PublicationRepository();
+  }
+
+  public async createPublication(
+    publication: PublicationCreationDTO
+  ): Promise<Result<IPublication>> {
+    try {
+      if (!publication) throw new Error('Los datos del libro son obligatorios');
+
+      const newPublication = await this.publicationRepository.Create(
+        publication
+      );
+
+      return generateResult(true, null, newPublication);
+    } catch (error) {
+      return generateResult(false, `${error}`);
+    }
+  }
+
+  public async getAllPublications(): Promise<Result<IPublication[]>> {
+    try {
+      const publications = await this.publicationRepository.FindAll();
+      return generateResult(true, null, publications);
+    } catch (error) {
+      return generateResult(false, `${error}`);
+    }
+  }
+
+  public async updatePublicationFields(
+    publication: Omit<IPublication, 'created_at'>
+  ): Promise<Result<IPublication>> {
+    try {
+      if (publication.id == null)
+        return generateResult(false, 'El ID es obligatorio');
+
+      const data = this.cleanInvalidValues(publication);
+
+      const updatedPublication = await this.publicationRepository.Update(
+        publication.id,
+        data
+      );
+
+      return generateResult(true, null, updatedPublication);
+    } catch (error) {
+      return generateResult(false, `${error}`);
+    }
+  }
+
+  public async deletePublicationbyId(
+    publicationId: number
+  ): Promise<Result<IPublication>> {
+    try {
+      if (!this.isOnlyNumber(publicationId))
+        return generateResult(false, 'El ID del libro debe ser de tipo INT');
+
+      const deletedThesis = await this.publicationRepository.Delete(
+        publicationId
+      );
+
+      return generateResult(true, null, deletedThesis);
+    } catch (error) {
+      return generateResult(false, 'error interno del servidor');
+    }
+  }
+
+  private cleanInvalidValues(
+    obj: PublicationCreationDTO
+  ): Partial<PublicationCreationDTO> {
+    const newObj: Partial<PublicationCreationDTO> = {};
+
+    for (const [key, value] of Object.entries(obj) as [
+      keyof PublicationCreationDTO,
+      any
+    ][]) {
+      if (value != null) {
+        newObj[key] = value;
+      }
+    }
+
+    return newObj;
+  }
+
+  private isOnlyNumber(value: number | string | undefined): boolean {
+    return typeof value === 'number' && !isNaN(value);
+  }
+}


### PR DESCRIPTION
## Background

[CVT-005]

Added a new feature centered on the publications management. This is a basic CRUD implementation with the main endpoints that manipulate the data through this new functionality.

## Changes done

- Added new repository, service, controller, and route files for publications module
- Publication validation schema added
- New Prisma migration made
- At index.ts added a new route for accessing the publications route

## Pending to be done

We have to add tests to prove the correct functionality of the new feature

## Checklist

- [X] I run the linter
- [ ] I updated the tests, if necessary
- [ ] I have deployed to AWS and confirm the changes work
- [X] I updated the documentation, if necessary
- [X] I added myself as an assignee, the proper labels (partner, enhancement/bug-fix/documentation) and milestone
- [ ] I added a sample output, if applicable, in the _Extra_ section
